### PR TITLE
Frida 17 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,63 @@
 # frida-ios-dump
 A tool for extracting decrypted IPA files from jailbroken devices.
 
+## Installation
+
+1. Install [frida](http://www.frida.re/) on your iOS device.
+2. Install `npm` on your local machine:
+   ```shell
+   brew install node # MacOS homebrew
+   pacman -S node npm # Arch Linux
+   apt install nodejs npm # Debian et al.
+   # for Windows, find a pre-built nodejs version at https://nodejs.org/en/download
+   ```
+3. Clone this project:
+   ```shell
+   git clone https://github.com/rec0de/frida-ios-dump.git
+   cd frida-ios-dump
+   ```
+4. Create a virtual environment.
+   ```shell
+   python -m venv --upgrade-deps .venv
+   source .venv/bin/activate
+   ```
+5. Run `pip install frida-tools --require-virtualenv` to install the Frida dependency.
+6. Run the following command to install agent dependencies:
+   ```shell
+   cd agent
+   npm install
+   ```
+7. Verify that the script works:
+   ```shell
+   cd ..
+   python decrypter.py --version
+   ```
+
+## Usage
+
+Connect your iOS device to your machine using a USB cable. (You can also decrypt iOS over Wireless using the remote communication provided by Frida, but USB is recommended) 
+
+Make sure that you're in the python virtual environment:
+
+```shell
+cd frida-ios-dump
+source .venv/bin/activate
+``` 
+
+Launch and decrypt an app by its bundle identifier:
+
+```shell
+python ./decrypter.py -U -f com.google.ios.youtube
+```
+
+Or decrypt an already running app by its display name:
+
+```shell
+python ./decrypter.py -U -n Spotify 
+```
+
 ## What's New?
+
 This fork **no longer requires** using `scp`, unlike the original project. 
 This is possible because I used the Frida [File API](https://frida.re/news/2022/07/06/frida-15-1-28-released/#:~:text=File%20API) to read all bytes inside a `Module` file and then parse it into a `MachO` object. 
 Currently, this class does not implement all [Apple specifications](https://github.com/apple-oss-distributions/xnu/blob/main/EXTERNAL_HEADERS/mach-o/loader.h).
@@ -11,43 +67,11 @@ After patching, I can send the file to PC/macOS using the [`send` Frida primitiv
 
 Furthermore, this solution extends the [`ConsoleApplication`](https://github.com/frida/frida-tools/blob/1ea077fdb49440e5807cf25fae41e389e3d2bd4a/frida_tools/application.py#L124-L134) class, thereby avoiding issues with argument handling.
 
-## Usage
+## Other Tools
 
-To use frida-ios-dump, follow these steps:
+You can decrypt apps that only run on recent iOS versions that you do not have a jailbreak for using a Mac with MacOS 11.2.3 or below (MacOS can be downgraded). See [UnFairPlay](https://github.com/subdiox/UnFairPlay) or [macOSAppstoreDecrypter](https://github.com/34306/macOSAppstoreDecrypter). [Dumpster](https://github.com/ChiChou/dumpster) can do the same on jailbroken iPhones.
 
-1. Install [frida](http://www.frida.re/) on your device.
-2. <span id="clone"></span>
-   Clone this project:
-   ```shell
-   git clone --depth=1 https://github.com/rec0de/frida-ios-dump.git
-   cd frida-ios-dump/
-   ```
-3. Create a virtual environment.
-   ```shell
-   python -m venv --upgrade-deps ./.venv
-   source ./.venv/bin/activate
-   ```
-4. Run `pip -vvv install frida-tools --require-virtualenv --upgrade --upgrade-strategy 'eager'` to install the Frida dependency.
-   > **Note**<br/>
-   > This command will also upgrade dependencies.
-5. (Optional) Connect your iDevice to macOS/PC using a USB lightning cable.
-   You can also decrypt iOS over Wireless using the remote communication provided by Frida, although USB is recommended.
-6. Run the following command to install agent dependencies:
-   ```shell
-   cd agent
-   npm -ddd install
-   ```
-7. Run the following commands to decrypt apps:
-   - ```shell
-     python ./decrypter.py -U -f com.google.ios.youtube
-     ```
-     This spawns YouTube and then decrypts it.
-   - ```shell
-     python ./decrypter.py -U -n Spotify 
-     ```
-     Use this after opening the Spotify app.
-
-## References
+## Further Reading
 
 - [Decrypting iPhone Apps](https://sensepost.com/blog/2011/decrypting-iphone-apps/)
 - [Decrypting iOS Binaries](https://mandalorianblog.wordpress.com/2013/05/03/decrypting-ios-binaries/)

--- a/README.md
+++ b/README.md
@@ -44,17 +44,20 @@ cd frida-ios-dump
 source .venv/bin/activate
 ``` 
 
-Launch and decrypt an app by its bundle identifier:
+Decrypt an already running app by its display name:
+
+```shell
+python ./decrypter.py -U -n Spotify 
+```
+
+Or launch and decrypt an app by its bundle identifier:
 
 ```shell
 python ./decrypter.py -U -f com.google.ios.youtube
 ```
 
-Or decrypt an already running app by its display name:
-
-```shell
-python ./decrypter.py -U -n Spotify 
-```
+> [!NOTE]
+> Launching apps with Frida via `-f` has [issues](https://github.com/frida/frida/issues/3484) with some versions of Dopamine (and possibly other jailbreaks) and may fail in strange ways.
 
 ## What's New?
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,10 @@ Furthermore, this solution extends the [`ConsoleApplication`](https://github.com
 To use frida-ios-dump, follow these steps:
 
 1. Install [frida](http://www.frida.re/) on your device.
-   > **Note**<br/>
-   > [My repo](https://miticollo.github.io/repos/) is no more necessary because since Frida 16.1.5 supports rootless and rootfull JB.
-   > Anyway if you want to compile your own Frida DEB you can run [my script](https://gist.github.com/miticollo/12e3fff5ba8fab7dd707c874105a508f#file-build_frida-sh).
 2. <span id="clone"></span>
-   Clone this project by entering the following command in your terminal:
+   Clone this project:
    ```shell
-   git clone --depth=1 https://github.com/miticollo/frida-ios-dump.git
+   git clone --depth=1 https://github.com/rec0de/frida-ios-dump.git
    cd frida-ios-dump/
    ```
 3. Create a virtual environment.
@@ -49,26 +46,6 @@ To use frida-ios-dump, follow these steps:
      python ./decrypter.py -U -n Spotify 
      ```
      Use this after opening the Spotify app.
-
-
-### How to install it?
-
-To install the app, sideload it as follows:
-- Use [Sideloadly](https://sideloadly.io/)
-  ![sideloadly.png](screenshots/sideloadly.png)
-  > **Note**<br/>
-  > Enable “Sideload Spoofer” as some apps may not work after decryption.
-
-## Tested environment
-
-- [Python3](https://github.com/pyenv/pyenv)
-
-### Devices and iOS Versions
-
-- iPhone XR with iOS 15.1b1 jailbroken using [Dopamine](https://github.com/opa334/Dopamine/releases/tag/1.1.5)
-- iPhone X with iOS 16.3.1 rootfull JB
-- [iPhone 8 with iOS 15.6 jailbroken using palera1n](https://twitter.com/mahochan1102/status/1749986132191002863?s=61&t=cJTiT29OrKBPSrNp_jldBw)
-- iPhone XR with iOS 15.1b1 jailbroken using RootHide
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To use frida-ios-dump, follow these steps:
    You can also decrypt iOS over Wireless using the remote communication provided by Frida, although USB is recommended.
 6. Run the following command to install agent dependencies:
    ```shell
+   cd agent
    npm -ddd install
    ```
 7. Run the following commands to decrypt apps:

--- a/agent/index.ts
+++ b/agent/index.ts
@@ -6,11 +6,10 @@ import { EncryptionInfo, EncryptionInfo64 } from './lib/macho/commands/encryptio
 import assert from 'node:assert';
 import { NSBundle } from './lib/types.js';
 import { Agent } from './lib/pull.js';
-import Java from "frida-java-bridge";
 import ObjC from "frida-objc-bridge";
 
 /* ObjC.available is buggy on non-objc apps, so override this */
-const ObjCAvailable: boolean = (Process.platform === 'darwin') && !(Java && Java.available) && ObjC && ObjC.available && ObjC.classes && typeof ObjC.classes['NSString'] !== 'undefined';
+const ObjCAvailable: boolean = (Process.platform === 'darwin') && ObjC && ObjC.available && ObjC.classes && typeof ObjC.classes['NSString'] !== 'undefined';
 if (!ObjCAvailable) throw new Error('This tool requires the objc runtime');
 
 const payloadPath: string = appPath['UTF8String']().match(/^\/private\/var\/containers\/Bundle\/Application\/[A-F0-9-]+/)[0];

--- a/agent/index.ts
+++ b/agent/index.ts
@@ -6,6 +6,8 @@ import { EncryptionInfo, EncryptionInfo64 } from './lib/macho/commands/encryptio
 import assert from 'node:assert';
 import { NSBundle } from './lib/types.js';
 import { Agent } from './lib/pull.js';
+import Java from "frida-java-bridge";
+import ObjC from "frida-objc-bridge";
 
 /* ObjC.available is buggy on non-objc apps, so override this */
 const ObjCAvailable: boolean = (Process.platform === 'darwin') && !(Java && Java.available) && ObjC && ObjC.available && ObjC.classes && typeof ObjC.classes['NSString'] !== 'undefined';

--- a/agent/lib/bundle.ts
+++ b/agent/lib/bundle.ts
@@ -1,5 +1,6 @@
 import { NSBundle, NSDictionary } from './types.js';
 import { manager } from './shared.js';
+import ObjC from "frida-objc-bridge";
 
 function infoDictionaryForPath(path: ObjC.Object): ObjC.Object | null {
     const infoPlistPath = path['stringByAppendingPathComponent_']("Info.plist");

--- a/agent/lib/dlopen.ts
+++ b/agent/lib/dlopen.ts
@@ -1,7 +1,8 @@
 export const RTLD_GLOBAL = 0x8;
 export const RTLD_LAZY = 0x1;
+const _usr_lib_system_libdyld_dylib = Process.getModuleByName('/usr/lib/system/libdyld.dylib');
 
-const _dlopen = new NativeFunction(Module.getExportByName('/usr/lib/system/libdyld.dylib', 'dlopen'), 'pointer', ['pointer', 'int']);
+const _dlopen = new NativeFunction(_usr_lib_system_libdyld_dylib.getExportByName('dlopen'), 'pointer', ['pointer', 'int']);
 
 export function dlopen(library: string, mode: number): NativePointer {
   const path: NativePointer = Memory.allocUtf8String(library);

--- a/agent/lib/shared.ts
+++ b/agent/lib/shared.ts
@@ -1,4 +1,5 @@
 import { NSBundle, NSFileManager } from "./types.js";
+import ObjC from "frida-objc-bridge";
 
 export const manager: ObjC.Object = NSFileManager["defaultManager"]();
 export const appPath: ObjC.Object = NSBundle["mainBundle"]().bundlePath();

--- a/agent/lib/types.ts
+++ b/agent/lib/types.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 const {
     NSBundle,
     NSFileManager,

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "decrypter-agent",
       "version": "1.0.0",
+      "dependencies": {
+        "frida-java-bridge": "^7.0.10",
+        "frida-objc-bridge": "^8.0.5"
+      },
       "devDependencies": {
         "@types/frida-gum": "^18.4.0",
         "@types/node": "22.7.3",
@@ -476,6 +480,18 @@
       "integrity": "sha512-Eyb4OqUlcv1/Eq7Q+B9IZmYZIgIM2YjqDojrjmAGzPSSXBuUKwSkuObQcQ8Dup9JTOMIUcSII9/I8DaTe6LFKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/frida-java-bridge": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/frida-java-bridge/-/frida-java-bridge-7.0.10.tgz",
+      "integrity": "sha512-AtjgAHE7a2wV6M/8tZvjVqda0T8YGmSoXqkbD0r1Eq6XTFDKYbClKbZqMYHpI9OjxtkIx+xPqkHWWE3+0fDH7w==",
+      "license": "LGPL-2.0 WITH WxWindows-exception-3.1"
+    },
+    "node_modules/frida-objc-bridge": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/frida-objc-bridge/-/frida-objc-bridge-8.0.5.tgz",
+      "integrity": "sha512-0xnL0VgxSQXgLj3S33S0kdAvLrCHSCIZb9HVraEgEyKnf9wOcu0KZ9fI5xzx0e0y+ry/g2Vl3yw9j3dsn92Ffg==",
+      "license": "LGPL-2.0 WITH WxWindows-exception-3.1"
     },
     "node_modules/frida-remote-stream": {
       "version": "6.0.2",

--- a/agent/package.json
+++ b/agent/package.json
@@ -13,5 +13,9 @@
     "@types/node": "22.7.3",
     "frida-compile": "^16.3.0",
     "frida-remote-stream": "^6.0.2"
+  },
+  "dependencies": {
+    "frida-java-bridge": "^7.0.10",
+    "frida-objc-bridge": "^8.0.5"
   }
 }


### PR DESCRIPTION
There's quite a few forks around that independently fix the agent script for Frida 17, so I figured it might be useful to have it in one of the more popular repos as well.

This PR should have the minimal required changes, code was automatically converted using codecolorist's [diciasette](https://github.com/ChiChou/diciassette).

Verified on frida 17.5.1